### PR TITLE
Support configuring the APNs environment

### DIFF
--- a/lib/courier/client.rb
+++ b/lib/courier/client.rb
@@ -5,9 +5,12 @@ module Courier
   class Client
     DEFAULT_BASE_URL = "https://courier.thoughtbot.com".freeze
 
-    def initialize(api_token:, base_url: DEFAULT_BASE_URL)
+    def initialize(api_token:,
+                   base_url: DEFAULT_BASE_URL,
+                   environment: "production")
       @api_token = api_token
       @base_url = base_url
+      @environment = environment
     end
 
     def broadcast(channel, payload)
@@ -20,14 +23,14 @@ module Courier
 
     private
 
-    attr_reader :api_token
-    attr_reader :base_url
+    attr_reader :api_token, :base_url, :environment
 
     def http
       Faraday.new(url: base_url) do |conn|
         conn.headers["Accept"] = "application/json version=1"
         conn.headers["Content-Type"] = "application/json"
         conn.request :json
+        conn.params["environment"] = environment
         conn.token_auth api_token
         conn.adapter Faraday.default_adapter
       end

--- a/spec/courier_spec.rb
+++ b/spec/courier_spec.rb
@@ -13,6 +13,7 @@ describe Courier do
           "Content-Type": "application/json",
           "Authorization": "Token token=\"#{api_token}\"",
         },
+        query: { environment: "production" },
         body: { broadcast: {
           payload: {
             "alert": "Hello from Courier",
@@ -29,6 +30,7 @@ describe Courier do
 
     it "returns a Broadcast model" do
       stub_request(:post, "https://courier.thoughtbot.com/broadcast/channel").
+        with(query: { environment: "production" }).
         to_return(status: 200)
 
       courier = Courier::Client.new(api_token: "token")
@@ -43,9 +45,21 @@ describe Courier do
     it "supports configuring the courier URL" do
       base_url = "https://example.com"
       url = "#{base_url}/broadcast/channel"
-      stub = stub_request(:post, url)
+      stub = stub_request(:post, url).with(query: { environment: "production" })
 
       courier = Courier::Client.new(api_token: "token", base_url: base_url)
+      courier.broadcast("channel", alert: "Hello from Courier")
+
+      expect(stub).to have_been_requested
+    end
+
+    it "supports configuring the environment" do
+      url = "https://courier.thoughtbot.com/broadcast/channel"
+      stub = stub_request(:post, url).with(query:
+                                           { environment: "development" })
+
+      courier = Courier::Client.new(api_token: "token",
+                                    environment: "development")
       courier.broadcast("channel", alert: "Hello from Courier")
 
       expect(stub).to have_been_requested


### PR DESCRIPTION
While testing https://trello.com/c/fGY86ZZZ/59-when-i-send-a-broadcast-i-don-t-want-the-request-to-fail-when-sending-the-notifications-take-too-long I realized I wasn't able to customize the APNs environment.

This resolves that :) 
