### PR TITLE
Interpret any 2xx status code as having sent a broadcast

### DIFF
--- a/lib/courier/broadcast.rb
+++ b/lib/courier/broadcast.rb
@@ -9,7 +9,7 @@ module Courier
     end
 
     def sent?
-      status_code == 200
+      (200..299).cover?(status_code)
     end
 
     def ==(other)

--- a/spec/broadcast_spec.rb
+++ b/spec/broadcast_spec.rb
@@ -10,6 +10,14 @@ module Courier
       expect(broadcast).to be_sent
     end
 
+    it "is sent when status_code is 201" do
+      broadcast = Broadcast.new(channel: "channel",
+                                payload: {},
+                                status_code: 201)
+
+      expect(broadcast).to be_sent
+    end
+
     it "is not sent when status_code is not 200" do
       broadcast = Broadcast.new(channel: "channel",
                                 payload: {},


### PR DESCRIPTION
We were explicitly checking for 200. However the API returns 201 when successful. To be safe this checks if the status code is in the 2xx range.